### PR TITLE
cr & terraform: cloud sql creds are now stored in gcp secrets.

### DIFF
--- a/explore-assistant-backend/terraform/cloud_run/main.tf
+++ b/explore-assistant-backend/terraform/cloud_run/main.tf
@@ -170,7 +170,7 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
 }
 
 output "cloud_run_uri" {
-  value = google_cloud_run_v2_service.default.traffic_statuses[0].uri
+  value = google_cloud_run_v2_service.default.uri
 }
 
 output "cloud_run_data" {

--- a/explore-assistant-backend/terraform/cloud_run/main.tf
+++ b/explore-assistant-backend/terraform/cloud_run/main.tf
@@ -33,6 +33,11 @@ variable "explore-assistant-cr-sa-id" {
   description = "service account for cloud run to use & make vertexai requests."
 }
 
+variable "cloudSQL_server_name" {
+  type = string
+  description = "prefix the cloud run use to source cloud sql secrets for db connection"
+}
+
 resource "google_service_account" "explore_assistant_sa" {
   account_id   = var.explore-assistant-cr-sa-id
   display_name = "Looker Explore Assistant Cloud Run SA"
@@ -82,6 +87,42 @@ resource "google_cloud_run_v2_service" "default" {
         value_source {
           secret_key_ref {
             secret  = "projects/${var.project_number}/secrets/looker-explore-assistant-admin-token"
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "CLOUD_SQL_HOST"
+        value_source {
+          secret_key_ref {
+            secret  = format("projects/${var.project_number}/secrets/looker-genai-cloud-sql-host-%s",var.cloudSQL_server_name)
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "CLOUD_SQL_PASSWORD"
+        value_source {
+          secret_key_ref {
+            secret  = format("projects/${var.project_number}/secrets/looker-genai-cloud-sql-password-%s",var.cloudSQL_server_name)
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "CLOUD_SQL_DATABASE"
+        value_source {
+          secret_key_ref {
+            secret  = format("projects/${var.project_number}/secrets/looker-genai-cloud-sql-database-%s",var.cloudSQL_server_name)
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "CLOUD_SQL_USER"
+        value_source {
+          secret_key_ref {
+            secret  = format("projects/${var.project_number}/secrets/looker-genai-cloud-sql-user-%s",var.cloudSQL_server_name)
             version = "latest"
           }
         }

--- a/explore-assistant-backend/terraform/cloud_run/main.tf
+++ b/explore-assistant-backend/terraform/cloud_run/main.tf
@@ -18,6 +18,17 @@ variable "project_number" {
   type = number
 }
 
+variable "looker_client_id" {
+  type = string
+}
+
+variable "looker_client_secret" {
+  type = string
+}
+
+variable "looker_api_url" {
+  type = string
+}
 variable "image" {
   description = "The full path to image on your Google artifacts repo"
   type        = string
@@ -142,6 +153,18 @@ resource "google_cloud_run_v2_service" "default" {
         name  = "PROJECT_NAME"
         value = var.project_id
       }
+      env {
+        name  = "LOOKER_CLIENT_ID"
+        value = var.looker_client_id
+      }
+      env {
+        name  = "LOOKER_CLIENT_SECRET"
+        value = var.looker_client_secret
+      }
+      env {
+        name  = "LOOKER_API_URL"
+        value = var.looker_api_url
+      }
     }
     service_account = google_service_account.explore_assistant_sa.email
   }
@@ -149,7 +172,7 @@ resource "google_cloud_run_v2_service" "default" {
     percent         = 100
     type = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
-  depends_on = [ google_project_iam_member.default ]
+  depends_on = [ google_service_account.explore_assistant_sa ]
 }
 
 ### IAM permissions for Cloud Run (public access)

--- a/explore-assistant-backend/terraform/cloud_run/main.tf
+++ b/explore-assistant-backend/terraform/cloud_run/main.tf
@@ -149,6 +149,7 @@ resource "google_cloud_run_v2_service" "default" {
     percent         = 100
     type = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
+  depends_on = [ google_project_iam_member.default ]
 }
 
 ### IAM permissions for Cloud Run (public access)

--- a/explore-assistant-backend/terraform/cloud_sql/main.tf
+++ b/explore-assistant-backend/terraform/cloud_sql/main.tf
@@ -135,6 +135,96 @@ resource "google_sql_user" "cloud_sql_user" {
   depends_on = [google_sql_database.production]
 }
 
+
+
+
+# Create secrets for Cloud SQL credentials
+resource "google_secret_manager_secret" "cloud_sql_host" {
+  project   = var.project_id
+  secret_id = format("looker-genai-cloud-sql-host-%s", var.cloudSQL_server_name)
+  
+  replication {
+        auto { 
+    }
+  }
+  
+}
+
+resource "google_secret_manager_secret" "cloud_sql_user" {
+  project   = var.project_id
+  secret_id = format("looker-genai-cloud-sql-user-%s", var.cloudSQL_server_name)
+  
+  replication {
+        auto { 
+    }
+  }
+  
+}
+
+resource "google_secret_manager_secret" "cloud_sql_password" {
+  project   = var.project_id
+  secret_id = format("looker-genai-cloud-sql-password-%s", var.cloudSQL_server_name)
+  
+  replication {
+        auto { 
+    }
+  }
+  
+}
+
+resource "google_secret_manager_secret" "cloud_sql_database" {
+  project   = var.project_id
+  secret_id = format("looker-genai-cloud-sql-database-%s", var.cloudSQL_server_name)
+  
+  replication {
+        auto { 
+    }
+  }
+  
+}
+
+
+# Create secret versions with actual values
+resource "google_secret_manager_secret_version" "cloud_sql_host_version" {
+  secret      = google_secret_manager_secret.cloud_sql_host.id
+  secret_data = google_sql_database_instance.main.public_ip_address
+  
+  depends_on = [
+    google_secret_manager_secret.cloud_sql_host,
+    google_sql_database_instance.main
+  ]
+}
+
+resource "google_secret_manager_secret_version" "cloud_sql_user_version" {
+  secret      = google_secret_manager_secret.cloud_sql_user.id
+  secret_data = google_sql_user.cloud_sql_user.name
+  
+  depends_on = [
+    google_secret_manager_secret.cloud_sql_user,
+    google_sql_user.cloud_sql_user
+  ]
+}
+
+resource "google_secret_manager_secret_version" "cloud_sql_password_version" {
+  secret      = google_secret_manager_secret.cloud_sql_password.id
+  secret_data = google_sql_user.cloud_sql_user.password
+  
+  depends_on = [
+    google_secret_manager_secret.cloud_sql_password,
+    google_sql_user.cloud_sql_user
+  ]
+}
+
+resource "google_secret_manager_secret_version" "cloud_sql_database_version" {
+  secret      = google_secret_manager_secret.cloud_sql_database.id
+  secret_data = google_sql_database.production.name
+  
+  depends_on = [
+    google_secret_manager_secret.cloud_sql_database,
+    google_sql_database.production
+  ]
+}
+
 output "cloudsql_instance_info" {
   value = {
     public_ip = google_sql_database_instance.main.public_ip_address

--- a/explore-assistant-backend/terraform/main.tf
+++ b/explore-assistant-backend/terraform/main.tf
@@ -103,8 +103,9 @@ module "cloud_run_backend" {
   cloud_run_service_name               = var.cloud_run_service_name
   explore-assistant-cr-oauth-client-id = var.explore-assistant-cr-oauth-client-id
   explore-assistant-cr-sa-id           = var.explore-assistant-cr-sa-id
+  cloudSQL_server_name                 = var.cloudSQL_server_name
 
-  depends_on = [module.cloud_sql,time_sleep.wait_after_apis_activate]
+  depends_on = [module.cloud_sql, time_sleep.wait_after_apis_activate]
 }
 
 module "bigquery_backend" {

--- a/explore-assistant-backend/terraform/main.tf
+++ b/explore-assistant-backend/terraform/main.tf
@@ -20,7 +20,7 @@ module "base-project-services" {
 
 resource "time_sleep" "wait_after_basic_apis_activate" {
   depends_on      = [module.base-project-services]
-  create_duration = "120s"
+  create_duration = "1s"
 }
 
 module "bg-backend-project-services" {
@@ -104,6 +104,9 @@ module "cloud_run_backend" {
   explore-assistant-cr-oauth-client-id = var.explore-assistant-cr-oauth-client-id
   explore-assistant-cr-sa-id           = var.explore-assistant-cr-sa-id
   cloudSQL_server_name                 = var.cloudSQL_server_name
+  looker_client_id                     = var.looker_client_id
+  looker_client_secret                 = var.looker_client_secret
+  looker_api_url                       = var.looker_api_url
 
   depends_on = [module.cloud_sql, time_sleep.wait_after_apis_activate]
 }

--- a/explore-assistant-backend/terraform/variables.tf
+++ b/explore-assistant-backend/terraform/variables.tf
@@ -84,6 +84,20 @@ variable "explore-assistant-cr-sa-id" {
 }
 
 
+variable "looker_client_id" {
+  type        = string
+  description = "client id for cr server to validate incoming requests are from valid users"
+}
+
+variable "looker_client_secret" {
+  type        = string
+  description = "client secret for cr server to validate incoming requests are from valid users"
+}
+
+variable "looker_api_url" {
+  type        = string
+  description = "api url to validate users against"
+}
 
 #
 # BIGQUERY VARIABLES

--- a/explore-assistant-backend/terraform/variables.tfvars.sample
+++ b/explore-assistant-backend/terraform/variables.tfvars.sample
@@ -11,3 +11,6 @@ explore-assistant-cr-sa-id           = "explore-assistant-cr-sa" # change to you
 root_password                        = "Your root user password"
 user_password                        = "Your mysql user password"
 cloudSQL_server_name                 = "Your cloudSQL server name"
+looker_client_id = "Your looker client id"
+looker_client_secret = "Your looker client secret"
+looker_api_url = "Your looker api url i.e. https://joonpartner.cloud.looker.com"

--- a/explore-assistant-cloud-run/Dockerfile
+++ b/explore-assistant-cloud-run/Dockerfile
@@ -19,7 +19,6 @@ COPY models.py /app/
 COPY helper_functions.py /app/
 COPY database.py /app/
 COPY test.py /app/
-COPY .env /app/
 
 EXPOSE 8080
 # Set the entrypoint to run the FastAPI app

--- a/explore-assistant-cloud-run/cloudrun_build.sh
+++ b/explore-assistant-cloud-run/cloudrun_build.sh
@@ -23,7 +23,7 @@ IMAGE_NAME="$IMAGE_NAME"
 ## hard coded
 REPO_NAME="looker-explore-assistant"
 REPOSITORY_REGION="$REGION_NAME-docker.pkg.dev"
-TAG="latest"
+TAG=${TAG:-latest}
 IMAGE="$REPOSITORY_REGION/$PROJECT_ID/$REPO_NAME/$IMAGE_NAME:$TAG"
 
 echo "Building Docker image..."


### PR DESCRIPTION
# Summary

- Patch the loop having to manually deploy cloud sql > push cloud run img > deploy cloud run > deploymain.
- Instead just a 2 step push cloud run img > deploy main
- Tested deploying & destroying successfully; CR can access the secrets & connect cloud sql
- Open PR to also fix #19 ; migrate looker creds to secret manager


# todo before merge
- [x] update README in cloud run to remove the env related to cloud sql & looker creds before pushing to docker repo. Users can keep them on for local build @nguyendnb 
- [x] Post the fine grained IAM permission required for this new workflow creating & storing gcp secrets. Ideally shouldn't be "Secrets Admin" for security reasons. @luutuankiet 