### PR TITLE
add optional looker delpoyment resource to tf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ plan.dat
 misc
 
 looker.ini
+explore_assistant_sa_key.json
+cloudsql_outputs.json

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ misc
 looker.ini
 explore_assistant_sa_key.json
 cloudsql_outputs.json
+table_names.json

--- a/explore-assistant-backend/terraform/cloud_run/main.tf
+++ b/explore-assistant-backend/terraform/cloud_run/main.tf
@@ -182,7 +182,7 @@ resource "google_cloud_run_v2_service" "default" {
     percent         = 100
     type = "TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST"
   }
-  depends_on = [ google_service_account.explore_assistant_sa ]
+  depends_on = [ google_service_account.explore_assistant_sa, google_project_iam_member.default ]
 }
 
 ### IAM permissions for Cloud Run (public access)

--- a/explore-assistant-backend/terraform/cloud_run/main.tf
+++ b/explore-assistant-backend/terraform/cloud_run/main.tf
@@ -74,6 +74,16 @@ resource "google_project_iam_member" "default" {
   role      = "roles/secretmanager.secretAccessor"
   member  = format("serviceAccount:%s", google_service_account.explore_assistant_sa.email)
 }
+resource "google_project_iam_member" "iam_permission_bq_job_user" {
+  project = var.project_id
+  role      = "roles/bigquery.jobUser"
+  member  = format("serviceAccount:%s", google_service_account.explore_assistant_sa.email)
+}
+resource "google_project_iam_member" "iam_permission_bq_connection_user" {
+  project = var.project_id
+  role      = "roles/bigquery.connectionUser"
+  member  = format("serviceAccount:%s", google_service_account.explore_assistant_sa.email)
+}
 
 resource "google_cloud_run_v2_service" "default" {
   name     = var.cloud_run_service_name
@@ -192,6 +202,22 @@ resource "google_cloud_run_service_iam_policy" "noauth" {
 
   policy_data = data.google_iam_policy.noauth.policy_data
 }
+
+
+resource "google_service_account_key"  "explore_assistant_sa_key" {
+  service_account_id = google_service_account.explore_assistant_sa.name
+  private_key_type   = "TYPE_GOOGLE_CREDENTIALS_FILE"
+  depends_on = [ google_service_account.explore_assistant_sa ]
+}
+
+# Save the key to a local file
+resource "local_file" "explore_assistant_sa_key_file" {
+  filename = "${path.module}/explore_assistant_sa_key.json"
+  content  = base64decode(google_service_account_key.explore_assistant_sa_key.private_key)
+  file_permission = "0600" 
+  depends_on = [ google_service_account_key.explore_assistant_sa_key ]
+}
+
 
 output "cloud_run_uri" {
   value = google_cloud_run_v2_service.default.uri

--- a/explore-assistant-backend/terraform/cloud_sql/create_tables.py
+++ b/explore-assistant-backend/terraform/cloud_sql/create_tables.py
@@ -1,6 +1,8 @@
-from database import create_db_and_tables, get_database_url
+from database import create_db_and_tables, get_database_url, engine
 import sys
 import os
+import json
+from sqlmodel import SQLModel, inspect
 
 # Add the root directory to the Python path
 root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../..'))
@@ -11,11 +13,39 @@ sys.path.insert(0, os.path.join(root_dir, 'explore-assistant-cloud-run'))
 # this will now import the foreign models table from cloud run folder
 import models
 
+def get_table_info():
+    """Extract information about all tables defined in SQLModel metadata"""
+    inspector = inspect(engine)
+    table_names = inspector.get_table_names()
+    
+    tables_info = {}
+    for table_name in table_names:
+        columns = inspector.get_columns(table_name)
+        tables_info[table_name] = {
+            "columns": [
+                {
+                    "name": column["name"],
+                    "type": str(column["type"]),
+                    "nullable": column.get("nullable", True),
+                    "default": str(column.get("default", "None")),
+                    "primary_key": column.get("primary_key", False)
+                }
+                for column in columns
+            ]
+        }
+    
+    return tables_info
+
 def main():
     print("Creating database and tables...")
     print(f"Using database URL: {get_database_url()}")
     create_db_and_tables()
     print("Tables created successfully!")
+    
+    # save a simple list of tables for Terraform to use
+    table_names = list(get_table_info().keys())
+    with open(os.path.join(os.path.dirname(__file__), "table_names.json"), "w") as f:
+        json.dump({"tables": table_names}, f)
 
 if __name__ == "__main__":
-    main() 
+    main()

--- a/explore-assistant-backend/terraform/cloud_sql/main.tf
+++ b/explore-assistant-backend/terraform/cloud_sql/main.tf
@@ -50,7 +50,7 @@ terraform {
 
 resource "google_sql_database_instance" "main" {
   database_version     = "MYSQL_8_0_31"
-  deletion_protection  = true
+  deletion_protection  = false
   encryption_key_name  = null
   instance_type        = "CLOUD_SQL_INSTANCE"
   master_instance_name = null
@@ -63,7 +63,6 @@ resource "google_sql_database_instance" "main" {
     availability_type           = "ZONAL"
     collation                   = null
     connector_enforcement       = "NOT_REQUIRED"
-    deletion_protection_enabled = false
     disk_autoresize             = true
     disk_autoresize_limit       = 0
     disk_size                   = 10

--- a/explore-assistant-backend/terraform/cloud_sql/variables.tfvars.sample
+++ b/explore-assistant-backend/terraform/cloud_sql/variables.tfvars.sample
@@ -1,5 +1,0 @@
-project_id = "joon-sandbox"
-deployment_region = "asia-southeast1"
-root_password = "Your root user password"
-user_password = "Your mysql user password"
-cloudSQL_server_name = "Your cloudSQL server name"

--- a/explore-assistant-backend/terraform/looker.tf
+++ b/explore-assistant-backend/terraform/looker.tf
@@ -1,0 +1,79 @@
+terraform {
+  required_providers {
+    looker = {
+      source  = "devoteamgcloud/looker"
+      version = "0.4.1-beta"
+    }
+  }
+}
+
+provider "looker" {
+  base_url      = var.looker_api_url
+  client_id     = var.looker_client_id
+  client_secret = var.looker_client_secret
+}
+
+
+# caveat : in order to have a flag to enable the deployment, needs to explicitly include this count param in each of the sub resource here.
+#   count        = var.deploy_looker_projects ? 1 : 0
+
+
+data "local_file" "cr_sa_key" {
+  filename   = "${path.root}/cloud_run/explore_assistant_sa_key.json"
+  depends_on = [module.cloud_run_backend.google_service_account_key]
+}
+
+
+# to read it : jsondecode(data.local_file.cr_sa_key.content)..... 
+locals {
+  username    = jsondecode(data.local_file.cr_sa_key.content).client_email
+  host        = jsondecode(data.local_file.cr_sa_key.content).project_id
+  database    = var.dataset_id_name
+  certificate = base64encode(data.local_file.cr_sa_key.content)
+
+
+  depends_on = [data.local_file.cr_sa_key]
+
+}
+
+
+
+resource "looker_connection" "looker_bq_connection" {
+  count        = var.deploy_looker_projects ? 1 : 0
+  name         = var.looker_connection_name
+  dialect_name = "bigquery_standard_sql"
+  host         = local.host
+  certificate  = local.certificate
+  file_type    = ".json"
+  database     = local.database
+  db_timezone  = "UTC"
+}
+
+resource "looker_project" "explore_assistant_poc_extension_project" {
+  count              = var.deploy_looker_projects ? 1 : 0
+  name               = var.looker_extension_project_name
+  rename_when_delete = true
+}
+
+resource "looker_project" "explore_assistant_performance_monitoring_project" {
+  count              = var.deploy_looker_projects ? 1 : 0
+  name               = var.looker_performance_monitoring_project_name
+  rename_when_delete = true
+}
+
+
+resource "looker_lookml_model" "explore_assistant_extension_model" {
+  count                       = var.deploy_looker_projects ? 1 : 0
+  name                        = var.looker_extension_project_name
+  project_name                = var.looker_extension_project_name
+  allowed_db_connection_names = [looker_connection.looker_bq_connection[0].name]
+  depends_on                  = [looker_project.explore_assistant_poc_extension_project]
+}
+
+resource "looker_lookml_model" "explore_assistant_performance_monitoring_model" {
+  count                       = var.deploy_looker_projects ? 1 : 0
+  name                        = var.looker_performance_monitoring_project_name
+  project_name                = var.looker_performance_monitoring_project_name
+  allowed_db_connection_names = [looker_connection.looker_bq_connection[0].name]
+  depends_on                  = [looker_project.explore_assistant_performance_monitoring_project]
+}

--- a/explore-assistant-backend/terraform/main.tf
+++ b/explore-assistant-backend/terraform/main.tf
@@ -90,6 +90,8 @@ module "cloud_sql" {
   user_password             = var.user_password
   cloudSQL_server_name      = var.cloudSQL_server_name
   bq_cloudsql_connection_id = var.bq_cloudsql_connection_id
+  dataset_id_name = var.dataset_id_name
+
 
 
   depends_on = [time_sleep.wait_after_apis_activate]

--- a/explore-assistant-backend/terraform/main.tf
+++ b/explore-assistant-backend/terraform/main.tf
@@ -20,7 +20,7 @@ module "base-project-services" {
 
 resource "time_sleep" "wait_after_basic_apis_activate" {
   depends_on      = [module.base-project-services]
-  create_duration = "1s"
+  create_duration = "120s"
 }
 
 module "bg-backend-project-services" {
@@ -90,7 +90,7 @@ module "cloud_sql" {
   user_password             = var.user_password
   cloudSQL_server_name      = var.cloudSQL_server_name
   bq_cloudsql_connection_id = var.bq_cloudsql_connection_id
-  dataset_id_name = var.dataset_id_name
+  dataset_id_name           = var.dataset_id_name
 
 
 

--- a/explore-assistant-backend/terraform/main.tf
+++ b/explore-assistant-backend/terraform/main.tf
@@ -82,13 +82,15 @@ resource "google_bigquery_dataset" "dataset" {
 }
 
 module "cloud_sql" {
-  count                = var.use_cloud_run_backend ? 1 : 0
-  source               = "./cloud_sql"
-  deployment_region    = var.deployment_region
-  project_id           = var.project_id
-  root_password        = var.root_password
-  user_password        = var.user_password
-  cloudSQL_server_name = var.cloudSQL_server_name
+  count                     = var.use_cloud_run_backend ? 1 : 0
+  source                    = "./cloud_sql"
+  deployment_region         = var.deployment_region
+  project_id                = var.project_id
+  root_password             = var.root_password
+  user_password             = var.user_password
+  cloudSQL_server_name      = var.cloudSQL_server_name
+  bq_cloudsql_connection_id = var.bq_cloudsql_connection_id
+
 
   depends_on = [time_sleep.wait_after_apis_activate]
 }

--- a/explore-assistant-backend/terraform/variables.tf
+++ b/explore-assistant-backend/terraform/variables.tf
@@ -57,6 +57,12 @@ variable "cloudSQL_server_name" {
   description = "value for the cloud SQL server name"
 }
 
+variable "bq_cloudsql_connection_id" {
+  type        = string
+  description = "name of the external bigquery connection to cloud sql"
+
+}
+
 
 #
 # CLOUD RUN VARIABLES

--- a/explore-assistant-backend/terraform/variables.tf
+++ b/explore-assistant-backend/terraform/variables.tf
@@ -119,3 +119,35 @@ variable "connection_id" {
   default = "explore_assistant_llm"
 }
 
+
+
+
+#
+# Looker variables
+#
+
+variable "deploy_looker_projects" {
+  description = "Optional flag to also provision looker infra from terraform."
+  type        = bool
+  default     = false
+}
+
+
+variable "looker_connection_name" {
+  type    = string
+  default = "explore_assistant_poc"
+}
+
+variable "looker_extension_project_name" {
+  type        = string
+  description = "the name of lookml model and project of the extension"
+  default     = "explore_assistant_poc_extension"
+
+}
+
+variable "looker_performance_monitoring_project_name" {
+  type        = string
+  description = "the name of lookml model and project of the performance monitoring feat"
+  default     = "explore_assistant_poc_performance_monitoring"
+
+}

--- a/explore-assistant-backend/terraform/variables.tfvars.sample
+++ b/explore-assistant-backend/terraform/variables.tfvars.sample
@@ -11,6 +11,7 @@ explore-assistant-cr-sa-id           = "explore-assistant-cr-sa" # change to you
 root_password                        = "Your root user password"
 user_password                        = "Your mysql user password"
 cloudSQL_server_name                 = "Your cloudSQL server name"
+bq_cloudsql_connection_id = "explore-assistant-cloudsql-connection"
 looker_client_id = "Your looker client id"
 looker_client_secret = "Your looker client secret"
 looker_api_url = "Your looker api url i.e. https://joonpartner.cloud.looker.com"

--- a/explore-assistant-backend/terraform/variables.tfvars.sample
+++ b/explore-assistant-backend/terraform/variables.tfvars.sample
@@ -15,3 +15,7 @@ bq_cloudsql_connection_id = "explore-assistant-cloudsql-connection"
 looker_client_id = "Your looker client id"
 looker_client_secret = "Your looker client secret"
 looker_api_url = "Your looker api url i.e. https://joonpartner.cloud.looker.com"
+deploy_looker_projects                     = false # set this to true to deploy looker project and models. disabled by default
+looker_connection_name                     = "explore_assistant_poc"
+looker_extension_project_name              = "explore_assistant_poc_extension"
+looker_performance_monitoring_project_name = "explore_assistant_poc_performance_monitoring"


### PR DESCRIPTION

## **Add Looker Deployment Resources to Terraform**

### **Overview**
This PR introduces optional **Looker deployment resources** into our Terraform configuration. It enables automated provisioning of Looker connections, projects, and models. 
This also create BQ views from  the cloud sql tables so that on looker side the developer can use the native "import tables" function saving time manually creating lookml views.

---

### **Key Changes**

#### 🔹 **Looker Integration**
- Added new **Terraform provider** for Looker resources.
- Created optional Terraform resources for:
  - Looker **connections**
  - Looker **projects**
  - Looker **models**
- Introduced a feature flag:  
  `deploy_looker_projects` (default: `false`) to control provisioning.

---

#### 🔹 **Cloud SQL & BigQuery Integration**
- Added a **BigQuery external connection** to **Cloud SQL**.
- Created **external views** in BigQuery that directly map to Cloud SQL tables.
- Configured **IAM roles**:
  - `roles/bigquery.jobUser`
  - `roles/bigquery.connectionUser`

---

#### 🔹 **Service Account Enhancements**
- Automated **service account key generation** for the Cloud Run service account.
- Assigned correct **IAM roles** for:
  - BigQuery **job execution**
  - BigQuery **connection usage**
- Fixed **dependency order** to prevent race conditions during deployment.

---

#### 🔹 **Database Schema Management**
- Improved the **Python utility script**:
  - Extracts table metadata from Cloud SQL.
  - Saves it in a Terraform-consumable format.
- Automatically creates **BigQuery views** for all relevant Cloud SQL tables.

---

#### 🔹 **Security & Cleanup**
- Ensured proper dependency handling so secrets are created **before** Cloud Run deployment.
- Set `deletion_protection = false` for the Cloud SQL instance to ease teardown.
