### PR TITLE
implement feedback category

### DIFF
--- a/explore-assistant-backend/terraform/bigquery_examples.tf
+++ b/explore-assistant-backend/terraform/bigquery_examples.tf
@@ -94,3 +94,29 @@ resource "google_bigquery_job" "create_explore_assistant_samples_table" {
     ignore_changes = [query, job_id]
   }
 }
+
+resource "google_bigquery_job" "create_explore_assistant_feedback_categories_table" {
+  job_id = "create_explore_assistant_feedback_categories_table-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  query {
+    query                 = <<EOF
+    CREATE OR REPLACE TABLE `${google_bigquery_dataset.dataset.dataset_id}.feedback_categories` (
+        name STRING OPTIONS (description = 'name of the category user will select'),
+        description STRING OPTIONS (description = 'category description')
+    )
+  EOF
+    create_disposition    = ""
+    write_disposition     = ""
+    allow_large_results   = false
+    flatten_results       = false
+    maximum_billing_tier  = 0
+    schema_update_options = []
+    use_legacy_sql        = false
+  }
+
+  location   = var.deployment_region
+  depends_on = [time_sleep.wait_after_apis_activate]
+
+  lifecycle {
+    ignore_changes = [query, job_id]
+  }
+}

--- a/explore-assistant-cloud-run/helper_functions.py
+++ b/explore-assistant-cloud-run/helper_functions.py
@@ -278,15 +278,10 @@ def _update_message(**kwargs) -> Message:
         raise DatabaseError("Failed to update message", str(e))
 
 
-def add_feedback(user_id: str, message_id: int, feedback_text: str, is_positive: bool) -> Feedback:
+def add_feedback(**kwargs) -> Feedback:
     try:
         with Session(engine) as session:
-            feedback = Feedback(
-                user_id=user_id,
-                message_id=message_id,
-                feedback_text=feedback_text,
-                is_positive=is_positive
-            )
+            feedback = Feedback(**kwargs)
             session.add(feedback)
             session.commit()
             return feedback

--- a/explore-assistant-cloud-run/main.py
+++ b/explore-assistant-cloud-run/main.py
@@ -321,7 +321,7 @@ async def give_feedback(
     db: Session = Depends(get_session)
 ):
     try:
-        result = add_feedback(request.user_id, request.message_id, request.feedback_text, request.is_positive)
+        result = add_feedback(**request.model_dump())
         if result:
             return BaseResponse(
                 message="Feedback submitted successfully",

--- a/explore-assistant-cloud-run/models.py
+++ b/explore-assistant-cloud-run/models.py
@@ -240,6 +240,7 @@ class Feedback(SQLModel, table=True):
     message_id: int = Field(foreign_key="messages.message_id")
     feedback_text: str
     is_positive: bool
+    category: Optional[str]
     timestamp: datetime = Field(default_factory=datetime.utcnow)
     
     message: Message = Relationship(back_populates="feedback")
@@ -274,6 +275,7 @@ class FeedbackRequest(BaseModel):
     message_id: int = Field(..., description="Message ID")
     feedback_text: str = Field(..., description="Feedback text")
     is_positive: bool = Field(..., description="Whether the feedback is positive")
+    category: Optional[str] = Field(default=None, description="The category selected by user")
 
 class BaseResponse(BaseModel):
     """Base model for successful responses"""

--- a/explore-assistant-examples/.env.example
+++ b/explore-assistant-examples/.env.example
@@ -3,3 +3,4 @@
 PROJECT_ID="PROJECT_ID"                          ##Required. The Google Cloud project ID where your BigQuery dataset resides.
 DATASET_ID="DATASET_ID"                          ##The ID of the BigQuery dataset. Defaults to explore_assistant.
 EXPLORE_ID="MODEL:EXPLORE_ID"                    ##Required. A unique identifier for the dataset rows related to a specific use case or query (used in deletion and insertion).
+LOCATION="asia-southeast1"

--- a/explore-assistant-examples/feedback_categories.csv
+++ b/explore-assistant-examples/feedback_categories.csv
@@ -1,0 +1,4 @@
+Name,Description
+Visualization,How well the provided visualization match the user input
+Query accuracy,How accurately the assistant translated the user’s natural language request into the correct query for Looker Explore.
+Other,Other categories not specified

--- a/explore-assistant-examples/feedback_categories.csv
+++ b/explore-assistant-examples/feedback_categories.csv
@@ -1,4 +1,4 @@
-Name,Description
+name,description
 Visualization,How well the provided visualization match the user input
 Query accuracy,How accurately the assistant translated the user’s natural language request into the correct query for Looker Explore.
 Other,Other categories not specified

--- a/explore-assistant-examples/load_feedback_categories.sh
+++ b/explore-assistant-examples/load_feedback_categories.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+if [ -f .env ]; then
+  # Automatically export all variables defined in .env
+  set -a
+  source .env
+  set +a
+else
+  echo ".env file not found!"
+  exit 1
+fi
+
+# check if user have gcloud
+if ! command -v bq &> /dev/null; then
+  echo "bq CLI not found. Please install the Google Cloud SDK: https://cloud.google.com/sdk/docs/install"
+  exit 1
+fi
+
+TABLE_NAME='feedback_categories'
+
+# starts the load
+
+echo "Loading data to '"$PROJECT_ID:$DATASET_ID.$TABLE_NAME"'..."
+
+bq load \
+    --location=$LOCATION \
+    --replace=true \
+    --source_format=CSV \
+    --schema=Name:STRING,Description:STRING \
+    --skip_leading_rows=1 \
+    "$PROJECT_ID:$DATASET_ID.$TABLE_NAME" \
+    "./$TABLE_NAME.csv"
+
+
+if [ $? -eq 0 ]; then
+  echo "✅ Load succeeded: $TABLE_NAME uploaded to $PROJECT_ID:$DATASET_ID"
+else
+  echo "❌ Load failed. Check the error messages above."
+  exit 1
+fi

--- a/explore-assistant-examples/load_feedback_categories.sh
+++ b/explore-assistant-examples/load_feedback_categories.sh
@@ -25,7 +25,7 @@ bq load \
     --location=$LOCATION \
     --replace=true \
     --source_format=CSV \
-    --schema=Name:STRING,Description:STRING \
+    --schema=name:STRING,description:STRING \
     --skip_leading_rows=1 \
     "$PROJECT_ID:$DATASET_ID.$TABLE_NAME" \
     "./$TABLE_NAME.csv"

--- a/explore-assistant-extension/src/components/Chat/Message.css
+++ b/explore-assistant-extension/src/components/Chat/Message.css
@@ -62,3 +62,18 @@
   transform: translateX(-50%);
   white-space: nowrap;
 }
+
+.feedback-dropdown {
+  width: 100%;
+  padding: 8px;
+  margin-bottom: 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 14px;
+  background-color: white;
+}
+
+.feedback-dropdown:focus {
+  outline: none;
+  border-color: #4285f4;
+}

--- a/explore-assistant-extension/src/components/Chat/Message.tsx
+++ b/explore-assistant-extension/src/components/Chat/Message.tsx
@@ -88,8 +88,9 @@ const Message = ({ message, actor, children, uuid, feedback }: MessageProps) => 
   const [feedbackVisible, setFeedbackVisible] = useState(false)
   const [feedbackText, setFeedbackText] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [selectedCategory, setSelectedCategory] = useState('')
   const [hasFeedback, setHasFeedback] = useState(false)
-  const { me, currentExploreThread } = useSelector((state: RootState) => state.assistant as AssistantState)
+  const { me, currentExploreThread, feedbackCategories } = useSelector((state: RootState) => state.assistant as AssistantState)
   const { access_token } = useSelector((state: RootState) => state.auth)
   const VERTEX_AI_ENDPOINT = process.env.VERTEX_AI_ENDPOINT || ''
   const userId = me.id
@@ -150,6 +151,7 @@ const Message = ({ message, actor, children, uuid, feedback }: MessageProps) => 
           message_id: uuid,
           feedback_text: feedbackText,
           is_positive: isThumbUpClicked,
+          category: selectedCategory,
         }),
       })
 
@@ -218,6 +220,23 @@ const Message = ({ message, actor, children, uuid, feedback }: MessageProps) => 
         )}
         {feedbackVisible && !hasFeedback && (
           <div className="feedback-form">
+            <select 
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(e.target.value)}
+              className="feedback-dropdown"
+              aria-label="Feedback category"
+            >
+              <option value="">Category (hover for info)</option>
+              {feedbackCategories.map((category) => (
+                <option 
+                  key={category.name} 
+                  value={category.name}
+                  title={category.description}
+                >
+                  {category.name}
+                </option>
+              ))}
+            </select>            
             <textarea
               value={feedbackText}
               onChange={(e) => setFeedbackText(e.target.value)}

--- a/explore-assistant-extension/src/hooks/useBigQueryExamples.ts
+++ b/explore-assistant-extension/src/hooks/useBigQueryExamples.ts
@@ -4,12 +4,14 @@ import {
   setExploreGenerationExamples,
   setExploreRefinementExamples,
   setExploreSamples,
+  setFeedbackCategories,
   ExploreSamples,
   setisBigQueryMetadataLoaded,
   setCurrenExplore,
   RefinementExamples,
   ExploreExamples,
-  AssistantState
+  AssistantState,
+  FeedbackCategory
 } from '../slices/assistantSlice'
 
 import { ExtensionContext } from '@looker/extension-sdk-react'
@@ -127,6 +129,36 @@ export const useBigQueryExamples = () => {
     }).catch((error) => showBoundary(error))
   }
 
+  const getFeedbackCategories = async () => {
+    const sql = `
+    SELECT
+        name,
+        description
+    FROM
+      \`${datasetName}.feedback_categories\`
+  `
+    return runSQLQuery(sql).then((response) => {
+      if(response.length === 0 || !Array.isArray(response)) {
+        return
+      }
+      const feedbackCategories: FeedbackCategory[] = []
+      
+      if(response.length === 0 || !Array.isArray(response)) {
+        return
+      }
+
+      response.forEach((row: any) => {
+        feedbackCategories.push({
+          name: row['name'],
+          description: row['description']
+        })
+      })
+
+      dispatch(setFeedbackCategories(feedbackCategories))
+    }).catch((error) => showBoundary(error))
+  }
+
+
   // Create a ref to track if the hook has already been called
   const hasFetched = useRef(false)
 
@@ -139,7 +171,7 @@ export const useBigQueryExamples = () => {
     if(isBigQueryMetadataLoaded) return
 
     dispatch(setisBigQueryMetadataLoaded(false))
-    Promise.all([getExamplePrompts(), getRefinementPrompts(), getSamples()])
+    Promise.all([getExamplePrompts(), getRefinementPrompts(), getSamples(), getFeedbackCategories()])
       .then(() => {
         dispatch(setisBigQueryMetadataLoaded(true))
       })

--- a/explore-assistant-extension/src/slices/assistantSlice.ts
+++ b/explore-assistant-extension/src/slices/assistantSlice.ts
@@ -371,6 +371,11 @@ interface Sample {
   prompt: string
 }
 
+export interface FeedbackCategory {
+  name: string;
+  description: string;
+}
+
 export interface Message {
   uuid: string
   message: string
@@ -473,6 +478,7 @@ export interface AssistantState {
   settings: Settings,
   isBigQueryMetadataLoaded: boolean,
   isSemanticModelLoaded: boolean
+  feedbackCategories: FeedbackCategory[]
 }
 
 export const newThreadState = createAsyncThunk(
@@ -571,6 +577,7 @@ export const initialState: AssistantState = {
   isBigQueryMetadataLoaded: false,
   isSemanticModelLoaded: false,
   isLoadingThreads: false,
+  feedbackCategories: []
 }
 export const assistantSlice = createSlice({
   name: 'assistant',
@@ -705,6 +712,12 @@ export const assistantSlice = createSlice({
       action: PayloadAction<AssistantState['examples']['exploreRefinementExamples']>,
     ) {
       state.examples.exploreRefinementExamples = action.payload
+    },
+    setFeedbackCategories(
+      state,
+      action: PayloadAction<AssistantState['feedbackCategories']>,
+    ) {
+      state.feedbackCategories = action.payload;
     },
     updateSummaryMessage: (
       state,
@@ -933,6 +946,7 @@ export const {
   setExploreGenerationExamples,
   setExploreRefinementExamples,
   setExploreSamples,
+  setFeedbackCategories,
 
   setisBigQueryMetadataLoaded,
 

--- a/explore-assistant-extension/src/store.ts
+++ b/explore-assistant-extension/src/store.ts
@@ -80,7 +80,7 @@ export const store = configureStore({
   reducer: persistedReducer,
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
-      serializableCheck: {
+      serializableCheck: { 
         ignoredActions: ['persist/PERSIST'],
       },
     }),


### PR DESCRIPTION
# Add Feedback Category Feature

https://joonsolutions.atlassian.net/browse/OLGAP-29

## Overview
This PR adds a feedback category dropdown to the user feedback form, allowing users to categorize their feedback when submitting it. Categories are loaded from BigQuery and displayed with helpful descriptions on hover.

The categories are loaded to the bigquery example dataset. 
Users can create a csv table & use script to upload on `explore-assistant-examples/load_feedback_categories.sh` 
The sample csv file looks like this : 

<details>

```
name,description
Visualization,How well the provided visualization match the user input
Query accuracy,How accurately the assistant translated the user’s natural language request into the correct query for Looker Explore.
Other,Other categories not specified

```

</details>


## Changes
- Added `FeedbackCategory` interface to `assistantSlice.ts` 
- Implemented BigQuery fetch for feedback categories in `useBigQueryExamples.ts`
- FE: Added category dropdown to feedback form in `Message.tsx` & include in call to endpoint `/feedback`
- BE: Updated feedback models to support `category` field
- Terraform: create `feedback_categories` table along with bigquery examples.


## Screenshots
![image](https://github.com/user-attachments/assets/e46388b9-0c64-4957-a707-08d76a525020)

![image](https://github.com/user-attachments/assets/62e5d1e5-9335-4d92-8ddb-7f4ddbc0b05c)

