### PR TITLE
Feat/add_user_restrictions

### DIFF
--- a/explore-assistant-backend/terraform/cloud_run/main.tf
+++ b/explore-assistant-backend/terraform/cloud_run/main.tf
@@ -49,6 +49,16 @@ variable "cloudSQL_server_name" {
   description = "prefix the cloud run use to source cloud sql secrets for db connection"
 }
 
+variable "restrict_group_access" {
+  type        = bool
+}
+
+variable "restrict_group_id" {
+  type        = string
+}
+
+
+
 resource "google_service_account" "explore_assistant_sa" {
   account_id   = var.explore-assistant-cr-sa-id
   display_name = "Looker Explore Assistant Cloud Run SA"
@@ -174,6 +184,14 @@ resource "google_cloud_run_v2_service" "default" {
       env {
         name  = "LOOKER_API_URL"
         value = var.looker_api_url
+      }
+      env {
+        name  = "RESTRICT_GROUP_ACCESS"
+        value = var.restrict_group_access
+      }
+      env {
+        name  = "RESTRICT_GROUP_ID"
+        value = var.restrict_group_id
       }
     }
     service_account = google_service_account.explore_assistant_sa.email

--- a/explore-assistant-backend/terraform/looker.tf
+++ b/explore-assistant-backend/terraform/looker.tf
@@ -77,3 +77,9 @@ resource "looker_lookml_model" "explore_assistant_performance_monitoring_model" 
   allowed_db_connection_names = [looker_connection.looker_bq_connection[0].name]
   depends_on                  = [looker_project.explore_assistant_performance_monitoring_project]
 }
+
+resource "looker_group" "restricted_group" {
+  count             = var.restrict_group_access ? 1 : 0
+  name              = var.looker_restricted_group_name
+  delete_on_destroy = true
+}

--- a/explore-assistant-backend/terraform/main.tf
+++ b/explore-assistant-backend/terraform/main.tf
@@ -111,6 +111,8 @@ module "cloud_run_backend" {
   looker_client_id                     = var.looker_client_id
   looker_client_secret                 = var.looker_client_secret
   looker_api_url                       = var.looker_api_url
+  restrict_group_id                    = (var.deploy_looker_projects && var.restrict_group_access) ? looker_group.restricted_group[0].id : ""
+  restrict_group_access                = var.restrict_group_access
 
   depends_on = [module.cloud_sql, time_sleep.wait_after_apis_activate]
 }

--- a/explore-assistant-backend/terraform/variables.tf
+++ b/explore-assistant-backend/terraform/variables.tf
@@ -105,6 +105,18 @@ variable "looker_api_url" {
   description = "api url to validate users against"
 }
 
+variable "restrict_group_access" {
+  type        = bool
+  description = "Set to true to enable Looker group access restriction for the extension."
+  default     = false
+}
+
+variable "looker_restricted_group_name" {
+  type        = string
+  description = "The name of the Looker group to be used for access restriction."
+  default     = "Explore Assistant Extension Users"
+}
+
 #
 # BIGQUERY VARIABLES
 #

--- a/explore-assistant-cloud-run/.env.sample
+++ b/explore-assistant-cloud-run/.env.sample
@@ -14,3 +14,8 @@ CLOUD_SQL_HOST="Your cloud sql host"
 CLOUD_SQL_DATABASE="Your cloud sql database"
 CLOUD_SQL_PASSWORD="Your cloud sql password"
 CLOUD_SQL_USER="Your cloud sql user"
+
+
+# restrict assistant access to a single looker group
+RESTRICT_GROUP_ACCESS=1 # set this variable to 0 or remove it if there is no user restriction requirements
+RESTRICT_GROUP_ID=25 # only applicable if RESTRICT_GROUP_ACCESS=1. The Looker group allowed to access this extension.

--- a/explore-assistant-cloud-run/requirements.txt
+++ b/explore-assistant-cloud-run/requirements.txt
@@ -15,3 +15,4 @@ httpx
 pytest-asyncio
 sqlmodel==0.0.14
 pymysql==1.1.0
+looker-sdk==25.10.0


### PR DESCRIPTION
# Summary
- Why : Once the extension is deployed it is available **to all explorer users** which is not ideal for client deployments that requires more iterative rollout i.e. Evaluate the assistant quality within a subset of users then slowly include more users.
- This PR adds 2 new env var for backend `RESTRICT_GROUP_ACCESS` and `RESTRICT_GROUP_ID`. 
  - If `RESTRICT_GROUP_ACCESS` is set, BE will perform an additional check if the interacting user has a matching group id defined in `RESTRICT_GROUP_ID`; throw error if this isn't met.
  - Otherwise if `RESTRICT_GROUP_ACCESS` is not met the check is bypassed i.e. all explorer users can interact with the assistant extension.
- The env var should be appropriately deployed to cloud run via terraform `variables.tfvars` / local server `.env` file.


![image](https://github.com/user-attachments/assets/c7ee518b-c16e-4139-8e2e-396c198a394c)
